### PR TITLE
Cart does not need shipping if the shipping method is Digital

### DIFF
--- a/classes/class-kss-shipping-method.php
+++ b/classes/class-kss-shipping-method.php
@@ -75,6 +75,11 @@ if ( class_exists( 'WC_Shipping_Method' ) ) {
 			$shipping_data   = get_transient( 'kss_data_' . $klarna_order_id );
 			$rate            = array();
 			if ( ! empty( $shipping_data ) ) {
+				if ( 'digital' === strtolower( $shipping_data['shipping_method'] ) ) {
+					add_filter( 'woocommerce_cart_needs_shipping', '__return_false' );
+					return;
+				}
+
 				$label = $shipping_data['name'];
 				// To prevent rounding issues from Klarna sending us a max of 2 decimals, we need to calculate the actual tax cost and subtract that from the total.
 				$cost                   = floatval( round( $shipping_data['price'] / ( 1 + ( $shipping_data['tax_rate'] / 10000 ) ), 2 ) ) / 100;


### PR DESCRIPTION
Klarna return "merchant-aggregator" if the cart does not need shipping.

If the cart contain a mix of digital and physical or only physical products, the behavior will be identical to how it was prior to this change.