### PR TITLE
Add HPOS compatibility

### DIFF
--- a/classes/class-kss-free-orders.php
+++ b/classes/class-kss-free-orders.php
@@ -68,31 +68,33 @@ class KSS_Free_Orders {
 		}
 
 		if ( $order_id && $klarna_order ) {
+			$order = wc_get_order( $order_id );
 
 			// Set WC order transaction ID.
-			update_post_meta( $order_id, '_wc_klarna_order_id', sanitize_key( $klarna_order['order_id'] ) );
+			$order->update_meta_data( '_wc_klarna_order_id', sanitize_key( $klarna_order['order_id'] ) );
 
-			update_post_meta( $order_id, '_transaction_id', sanitize_key( $klarna_order['order_id'] ) );
+			$order->update_meta_data( '_transaction_id', sanitize_key( $klarna_order['order_id'] ) );
 
 			$environment = $this->testmode ? 'test' : 'live';
-			update_post_meta( $order_id, '_wc_klarna_environment', $environment );
+			$order->update_meta_data( '_wc_klarna_environment', $environment );
 
 			$klarna_country = wc_get_base_location()['country'];
-			update_post_meta( $order_id, '_wc_klarna_country', $klarna_country );
+			$order->update_meta_data( '_wc_klarna_country', $klarna_country );
 
 			// Set shipping phone and email.
-			update_post_meta( $order_id, '_shipping_phone', sanitize_text_field( $klarna_order['shipping_address']['phone'] ) );
-			update_post_meta( $order_id, '_shipping_email', sanitize_text_field( $klarna_order['shipping_address']['email'] ) );
+			$order->update_meta_data( '_shipping_phone', sanitize_text_field( $klarna_order['shipping_address']['phone'] ) );
+			$order->update_meta_data( '_shipping_email', sanitize_text_field( $klarna_order['shipping_address']['email'] ) );
+
+			$order->save();
 
 			// Update the order with new confirmation page url.
 			$klarna_order = KCO_WC()->api->update_klarna_order( $klarna_order_id, $order_id );
 
-			$order->save();
 			// Let other plugins hook into this sequence.
 			do_action( 'kco_wc_process_payment', $order_id, $klarna_order );
 
 			// Check that the transaction id got set correctly.
-			if ( get_post_meta( $order_id, '_transaction_id', true ) === $klarna_order_id ) {
+			if ( $order->get_meta( '_transaction_id', true ) === $klarna_order_id ) {
 				return true;
 			}
 		}

--- a/klarna-shipping-service-for-woocommerce.php
+++ b/klarna-shipping-service-for-woocommerce.php
@@ -62,6 +62,20 @@ class Klarna_Shipping_Service_For_WooCommerce {
 	 */
 	public function init() {
 		$this->include_files();
+
+		add_action( 'before_woocommerce_init', array( $this, 'declare_wc_compatability' ) );
+	}
+
+	/**
+	 * Declare compatibility with WooCommerce features.
+	 *
+	 * @return void
+	 */
+	public function declare_wc_compatability() {
+		// Declare HPOS compatibility.
+		if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+		}
 	}
 
 	/**
@@ -106,9 +120,12 @@ class Klarna_Shipping_Service_For_WooCommerce {
 	 */
 	public function add_shipping_details_to_order( $order_id, $klarna_order ) {
 		if ( isset( $klarna_order['selected_shipping_option'] ) ) {
+			$order = wc_get_order( $order_id );
+
 			$shipping_details = $klarna_order['selected_shipping_option'];
-			update_post_meta( $order_id, '_kco_kss_data', wp_json_encode( $shipping_details, JSON_UNESCAPED_UNICODE ) );
-			update_post_meta( $order_id, '_kco_kss_reference', $shipping_details['tms_reference'] );
+			$order->update_meta_data( '_kco_kss_data', wp_json_encode( $shipping_details, JSON_UNESCAPED_UNICODE ) );
+			$order->update_meta_data( '_kco_kss_reference', $shipping_details['tms_reference'] );
+			$order->save();
 			WC()->session->__unset( 'kco_kss_enabled' );
 		}
 	}


### PR DESCRIPTION
As described in the [recipe book](https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book):
- `get_post( $post_id )` → `wc_get_order( $post_id )`
- `update_post_meta` → `WC_Order::update_meta_data`
- `add_post_meta` → `WC_Order::add_meta_data`
- `delete_post_meta` → `WC_Order::delete_meta_data`

Furthermore, where applicable, if a method is available for the meta field, that will be used in favor of retrieving it through the meta data function.  For example,  

```
get_post_meta($order_id, '_transaction_id', true)
```
is replaced with 
```
WC_Order::get_transaction_id()
```

If a meta data function is available, and update_meta_data is still used for that meta data, WooCommerce will warn about directly modifying internal meta data.

Note:
1. The HPOS-related methods _must_ be followed at some point by a `save()` call.
2. The recipe book does not seem to reference a replacement for `get_post_meta`, but this should be replaced by `WC_Order::get_meta`.