### PR TITLE
Handle tax-inclusive shipping prices

### DIFF
--- a/classes/class-kss-shipping-method.php
+++ b/classes/class-kss-shipping-method.php
@@ -96,10 +96,10 @@ if ( class_exists( 'WC_Shipping_Method' ) ) {
 
 				$label = $shipping_data['name'];
 				if ( apply_filters( 'woocommerce_shipping_prices_include_tax', false ) ) {
-					// Shipping prices are entered including tax — pass Kustom's price through as-is and let WooCommerce reverse-calculate the tax.
+					// Shipping prices are entered including tax in WooCommerce — pass Kustom's price through as-is and let WooCommerce reverse-calculate the tax.
 					$cost = floatval( $shipping_data['price'] ) / 100;
 				} else {
-					// To prevent rounding issues from Kustom sending us a max of 2 decimals, we need to calculate the actual tax cost and subtract that from the total.
+					// Shipping prices are entered excluding tax in WooCommerce (default) - we need to calculate the actual tax cost and subtract that from the total.
 					$cost = floatval( round( $shipping_data['price'] / ( 1 + ( $shipping_data['tax_rate'] / 10000 ) ), 2 ) ) / 100;
 				}
 				$tax_amount             = floatval( $shipping_data['tax_amount'] ) / 100;

--- a/classes/class-kss-shipping-method.php
+++ b/classes/class-kss-shipping-method.php
@@ -95,8 +95,13 @@ if ( class_exists( 'WC_Shipping_Method' ) ) {
 				}
 
 				$label = $shipping_data['name'];
-				// To prevent rounding issues from Kustom sending us a max of 2 decimals, we need to calculate the actual tax cost and subtract that from the total.
-				$cost                   = floatval( round( $shipping_data['price'] / ( 1 + ( $shipping_data['tax_rate'] / 10000 ) ), 2 ) ) / 100;
+				if ( apply_filters( 'woocommerce_shipping_prices_include_tax', false ) ) {
+					// Shipping prices are entered including tax — pass Kustom's price through as-is and let WooCommerce reverse-calculate the tax.
+					$cost = floatval( $shipping_data['price'] ) / 100;
+				} else {
+					// To prevent rounding issues from Kustom sending us a max of 2 decimals, we need to calculate the actual tax cost and subtract that from the total.
+					$cost = floatval( round( $shipping_data['price'] / ( 1 + ( $shipping_data['tax_rate'] / 10000 ) ), 2 ) ) / 100;
+				}
 				$tax_amount             = floatval( $shipping_data['tax_amount'] ) / 100;
 				$this->kss_tax_amount   = $tax_amount;
 				$this->kss_total_amount = $cost;


### PR DESCRIPTION
Add a check for woocommerce_shipping_prices_include_tax and, when shipping prices include tax, use Kustom's provided price as-is (divided by 100) so WooCommerce can reverse-calculate tax. When prices are tax-exclusive, keep the existing rounding logic to strip tax from the Kustom price to avoid rounding issues. Preserves assignment of kss_tax_amount and kss_total_amount.