### PR TITLE
Develop subscription free trial issue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,17 @@
-# Auto detect text files and perform LF normalization
-* text=auto
+# Based on the WooCommerce .gitattributes file: https://github.com/woocommerce/woocommerce/blob/trunk/.gitattributes
+*       text=auto
+
+# Force LF In Configuration Files
+*.md    text    eol=lf
+*.json  text    eol=lf
+*.yml   text    eol=lf
+
+# Force LF In Code Files
+*.php   text    eol=lf
+*.sh    text    eol=lf
+*.js    text    eol=lf
+*.jsx   text    eol=lf
+*.ts    text    eol=lf
+*.tsx   text    eol=lf
+*.css   text    eol=lf
+*.scss  text    eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 # Synch files
 .dat
+
+vendor/

--- a/.kernlignore
+++ b/.kernlignore
@@ -6,3 +6,9 @@
 .gitattributes
 Dockerfile
 docker-compose.yml
+readme.dev.md
+phpstan.neon
+phpstan-baseline.neon
+phpcs.xml
+composer.json
+composer.lock

--- a/classes/class-kss-edit-klarna-order.php
+++ b/classes/class-kss-edit-klarna-order.php
@@ -47,14 +47,16 @@ class KSS_Edit_Klarna_Order {
 	 * @return array
 	 */
 	public function remove_shipping( $request_args ) {
-		// Skip if we have override KSS data for this order.
-		$kco_order_id = WC()->session->get( 'kco_wc_order_id' );
+		// If the session is available, see if we have any override data for the shipping option.
+		if ( null !== WC()->session ) {
+			$kco_order_id = WC()->session->get( 'kco_wc_order_id' );
 
-		// If we have the override data for the shipping option, we should not remove the shipping line,
-		// since we have replaced it with the updated shipping data from WooCommerce instead.
-		$override_data = get_transient( "kss_override_data_$kco_order_id" );
-		if ( $override_data ) {
-			return $request_args;
+			// If we have the override data for the shipping option, we should not remove the shipping line,
+			// since we have replaced it with the updated shipping data from WooCommerce instead.
+			$override_data = get_transient( "kss_override_data_$kco_order_id" );
+			if ( $override_data ) {
+				return $request_args;
+			}
 		}
 
 		if ( isset( $request_args['order_lines'] ) ) {

--- a/classes/class-kss-edit-klarna-order.php
+++ b/classes/class-kss-edit-klarna-order.php
@@ -19,7 +19,6 @@ class KSS_Edit_Klarna_Order {
 	public function __construct() {
 		add_filter( 'kco_wc_api_request_args', array( $this, 'maybe_add_free_shipping_tag' ) );
 		add_filter( 'kco_wc_api_request_args', array( $this, 'remove_shipping' ) );
-		add_filter( 'kco_wc_api_request_args', array( $this, 'remove_shipping_callback_url' ) );
 	}
 
 	/**
@@ -48,6 +47,16 @@ class KSS_Edit_Klarna_Order {
 	 * @return array
 	 */
 	public function remove_shipping( $request_args ) {
+		// Skip if we have override KSS data for this order.
+		$kco_order_id = WC()->session->get( 'kco_wc_order_id' );
+
+		// If we have the override data for the shipping option, we should not remove the shipping line,
+		// since we have replaced it with the updated shipping data from WooCommerce instead.
+		$override_data = get_transient( "kss_override_data_$kco_order_id" );
+		if ( $override_data ) {
+			return $request_args;
+		}
+
 		if ( isset( $request_args['order_lines'] ) ) {
 			foreach ( $request_args['order_lines'] as $key => $order_line ) {
 				if ( isset( $order_line['type'] ) && 'shipping_fee' === $order_line['type'] ) {
@@ -74,4 +83,4 @@ class KSS_Edit_Klarna_Order {
 		}
 		return $request_args;
 	}
-} new KSS_Edit_Klarna_Order();
+} new KSS_Edit_Klarna_Order(); // phpcs:ignore PSR2.Classes.ClassDeclaration.CloseBraceSameLine -- Legacy

--- a/classes/class-kss-edit-klarna-order.php
+++ b/classes/class-kss-edit-klarna-order.php
@@ -70,17 +70,4 @@ class KSS_Edit_Klarna_Order {
 		}
 		return $request_args;
 	}
-
-	/**
-	 * Removes the shipping callback url incase it is set.
-	 *
-	 * @param array $request_args The request args for Kustom Checkout.
-	 * @return array
-	 */
-	public function remove_shipping_callback_url( $request_args ) {
-		if ( isset( $request_args['merchant_urls']['shipping_option_update'] ) ) {
-			unset( $request_args['merchant_urls']['shipping_option_update'] );
-		}
-		return $request_args;
-	}
 } new KSS_Edit_Klarna_Order(); // phpcs:ignore PSR2.Classes.ClassDeclaration.CloseBraceSameLine -- Legacy

--- a/classes/class-kss-shipping-method.php
+++ b/classes/class-kss-shipping-method.php
@@ -87,18 +87,19 @@ if ( class_exists( 'WC_Shipping_Method' ) ) {
 			$cost            = 0;
 			$klarna_order_id = WC()->session->get( 'kco_wc_order_id' );
 			$shipping_data   = get_transient( 'kss_data_' . $klarna_order_id );
+			$rate            = array();
 
-			// If we have the override data for the shipping option, use that.
-			$override_data = get_transient( "kss_override_data_$klarna_order_id" );
-			if ( $override_data ) {
-				$shipping_data['price']      = $override_data['price'] ?? $shipping_data['price'];
-				$shipping_data['name']       = $override_data['name'] ?? $shipping_data['name'];
-				$shipping_data['tax_rate']   = $override_data['tax_rate'] ?? $shipping_data['tax_rate'];
-				$shipping_data['tax_amount'] = $override_data['tax_amount'] ?? $shipping_data['tax_amount'];
-			}
-
-			$rate = array();
 			if ( ! empty( $shipping_data ) ) {
+				// If we have the override data for the shipping option, use that.
+				$override_data = get_transient( "kss_override_data_$klarna_order_id" );
+
+				if ( $override_data ) {
+					$shipping_data['price']      = $override_data['price'] ?? $shipping_data['price'];
+					$shipping_data['name']       = $override_data['name'] ?? $shipping_data['name'];
+					$shipping_data['tax_rate']   = $override_data['tax_rate'] ?? $shipping_data['tax_rate'];
+					$shipping_data['tax_amount'] = $override_data['tax_amount'] ?? $shipping_data['tax_amount'];
+				}
+
 				if ( isset( $shipping_data['shipping_method'] ) && 'digital' === strtolower( $shipping_data['shipping_method'] ) ) {
 					add_filter( 'woocommerce_cart_needs_shipping', '__return_false' );
 					return;

--- a/classes/class-kss-shipping-method.php
+++ b/classes/class-kss-shipping-method.php
@@ -87,7 +87,14 @@ if ( class_exists( 'WC_Shipping_Method' ) ) {
 			$cost            = 0;
 			$klarna_order_id = WC()->session->get( 'kco_wc_order_id' );
 			$shipping_data   = get_transient( 'kss_data_' . $klarna_order_id );
-			$rate            = array();
+
+			// If we have the override data for the shipping option, use that.
+			$override_data = get_transient( "kss_override_data_$klarna_order_id" );
+			if ( $override_data ) {
+				$shipping_data = $override_data;
+			}
+
+			$rate = array();
 			if ( ! empty( $shipping_data ) ) {
 				if ( isset( $shipping_data['shipping_method'] ) && 'digital' === strtolower( $shipping_data['shipping_method'] ) ) {
 					add_filter( 'woocommerce_cart_needs_shipping', '__return_false' );
@@ -114,7 +121,7 @@ if ( class_exists( 'WC_Shipping_Method' ) ) {
 
 					/* WPML do not respect the meta data currency property. */
 					global $woocommerce_wpml;
-					if ( isset( $woocommerce_wpml ) && $woocommerce_wpml->settings['enable_multi_currency'] == WCML_MULTI_CURRENCIES_INDEPENDENT ) {
+					if ( isset( $woocommerce_wpml ) && WCML_MULTI_CURRENCIES_INDEPENDENT === $woocommerce_wpml->settings['enable_multi_currency'] ) {
 						$rate['cost'] = $woocommerce_wpml->multi_currency->prices->unconvert_price_amount( $rate['cost'], $shipping_data['currency'] );
 					}
 				}
@@ -130,7 +137,7 @@ if ( class_exists( 'WC_Shipping_Method' ) ) {
 	 * @param array $methods WooCommerce shipping methods.
 	 * @return array
 	 */
-	function add_kss_shipping_method( $methods ) {
+	function add_kss_shipping_method( $methods ) { // phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed -- Legacy
 		$methods['klarna_kss'] = 'KSS_Shipping_Method';
 		return $methods;
 	}

--- a/classes/class-kss-shipping-method.php
+++ b/classes/class-kss-shipping-method.php
@@ -91,7 +91,10 @@ if ( class_exists( 'WC_Shipping_Method' ) ) {
 			// If we have the override data for the shipping option, use that.
 			$override_data = get_transient( "kss_override_data_$klarna_order_id" );
 			if ( $override_data ) {
-				$shipping_data = $override_data;
+				$shipping_data['price']      = $override_data['price'] ?? $shipping_data['price'];
+				$shipping_data['name']       = $override_data['name'] ?? $shipping_data['name'];
+				$shipping_data['tax_rate']   = $override_data['tax_rate'] ?? $shipping_data['tax_rate'];
+				$shipping_data['tax_amount'] = $override_data['tax_amount'] ?? $shipping_data['tax_amount'];
 			}
 
 			$rate = array();
@@ -126,6 +129,7 @@ if ( class_exists( 'WC_Shipping_Method' ) ) {
 					}
 				}
 			}
+
 			$this->add_rate( apply_filters( 'klarna_kss_shipping_method_add_rate', $rate ) );
 		}
 	}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,31 @@
+{
+    "require-dev": {
+        "wp-coding-standards/wpcs": "^3.1",
+        "php-stubs/woocommerce-stubs": "^10.0",
+        "szepeviktor/phpstan-wordpress": "^2.0",
+        "php-stubs/woocommerce-subscriptions-stubs": "^8.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "Krokedil\\KustomShippingService\\": "src/"
+        }
+    },
+    "config": {
+        "platform-check": false,
+        "platform": {
+            "php": "7.4"
+        },
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true
+        }
+    },
+    "scripts": {
+        "lint": "vendor/bin/phpcs . --standard=phpcs.xml --extensions=php -q -s",
+        "lint:fix": "vendor/bin/phpcbf . --standard=phpcs.xml --extensions=php -q -s",
+        "lint:changes": "git diff --name-only HEAD~1 | grep '\\.php$' | xargs vendor/bin/phpcs --standard=phpcs.xml --extensions=php -q -s",
+        "lint:fix:changes": "git diff --name-only HEAD~1 | grep '\\.php$' | xargs vendor/bin/phpcbf --standard=phpcs.xml --extensions=php -q -s",
+        "phpstan": "./vendor/bin/phpstan analyse --memory-limit=1G",
+        "phpstan:baseline": "./vendor/bin/phpstan analyse --memory-limit=1G --generate-baseline"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,696 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "40695b07eb3a8397b0d6504678375535",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-05-06T08:26:05+00:00"
+        },
+        {
+            "name": "php-stubs/woocommerce-stubs",
+            "version": "v10.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/woocommerce-stubs.git",
+                "reference": "7251902ebc048626aff04855c333afa9f3bae2d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/7251902ebc048626aff04855c333afa9f3bae2d5",
+                "reference": "7251902ebc048626aff04855c333afa9f3bae2d5",
+                "shasum": ""
+            },
+            "require": {
+                "php-stubs/wordpress-stubs": "^5.3 || ^6.0"
+            },
+            "require-dev": {
+                "php": "~7.1 || ~8.0",
+                "php-stubs/generator": "^0.8.0"
+            },
+            "suggest": {
+                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WooCommerce function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/woocommerce-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "woocommerce",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v10.7.0"
+            },
+            "time": "2026-04-14T15:19:28+00:00"
+        },
+        {
+            "name": "php-stubs/woocommerce-subscriptions-stubs",
+            "version": "v8.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/woocommerce-subscriptions-stubs.git",
+                "reference": "6e225945956a40d711432a08a9f13d6cbad04922"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-subscriptions-stubs/zipball/6e225945956a40d711432a08a9f13d6cbad04922",
+                "reference": "6e225945956a40d711432a08a9f13d6cbad04922",
+                "shasum": ""
+            },
+            "require": {
+                "php-stubs/woocommerce-stubs": "^10.2",
+                "php-stubs/wordpress-stubs": "^5.3 || ^6.0"
+            },
+            "require-dev": {
+                "php": "~7.4 || ~8.1",
+                "php-stubs/generator": "^0.8.0"
+            },
+            "suggest": {
+                "symfony/polyfill-php74": "Symfony polyfill backporting some PHP 7.4+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WooCommerce Subscriptions function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/woocommerce-subscriptions-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "subscription",
+                "woocommerce",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/woocommerce-subscriptions-stubs/issues",
+                "source": "https://github.com/php-stubs/woocommerce-subscriptions-stubs/tree/v8.4.0"
+            },
+            "time": "2026-02-14T10:11:19+00:00"
+        },
+        {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.9.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "shasum": ""
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "5.6.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^5.5",
+                "php": "^7.4 || ^8.0",
+                "php-stubs/generator": "^0.8.6",
+                "phpdocumentor/reflection-docblock": "^6.0",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^9.5",
+                "symfony/polyfill-php80": "*",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.4"
+            },
+            "time": "2026-05-01T20:36:01+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "b598aa890815b8df16363271b659d73280129101"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/b598aa890815b8df16363271b659d73280129101",
+                "reference": "b598aa890815b8df16363271b659d73280129101",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-12T23:06:57+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-12-08T14:27:58+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.56",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/93a603c9fc3be8c3c93bbc8d22170ad766685537",
+                "reference": "93a603c9fc3be8c3c93bbc8d22170ad766685537",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-26T17:04:57+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-04T16:30:35+00:00"
+        },
+        {
+            "name": "szepeviktor/phpstan-wordpress",
+            "version": "v2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
+                "reference": "aa722f037b2d034828cd6c55ebe9e5c74961927e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/aa722f037b2d034828cd6c55ebe9e5c74961927e",
+                "reference": "aa722f037b2d034828cd6c55ebe9e5c74961927e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "php-stubs/wordpress-stubs": "^6.6.2",
+                "phpstan/phpstan": "^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.1.14",
+                "composer/semver": "^3.4",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.0",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "swissspidy/phpstan-no-private": "Detect usage of internal core functions, classes and methods"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SzepeViktor\\PHPStan\\WordPress\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress extensions for PHPStan",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v2.0.3"
+            },
+            "time": "2025-09-14T02:58:22+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
+                "php": ">=7.2",
+                "phpcsstandards/phpcsextra": "^1.5.0",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.4"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
+            },
+            "suggest": {
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2025-11-25T12:08:04+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "platform-overrides": {
+        "php": "7.4"
+    },
+    "plugin-api-version": "2.9.0"
+}

--- a/klarna-shipping-service-for-woocommerce.php
+++ b/klarna-shipping-service-for-woocommerce.php
@@ -238,10 +238,13 @@ class Klarna_Shipping_Service_For_WooCommerce {
 			WC()->session->__unset( 'kco_kss_enabled' );
 		}
 
-		// Bump the shipping transient version so WooCommerce re-runs shipping for ALL packages,
-		// including Subscriptions' recurring packages (their package hash doesn't change when the
-		// override transient changes, so unsetting only the main-cart package keys isn't enough).
-		WC_Cache_Helper::get_transient_version( 'shipping', true );
+		// Clear this customer's cached shipping rates so WooCommerce re-runs shipping on the next
+		// calculation. We unset every 'shipping_for_package_*' session key (not just the main-cart packages)
+		foreach ( array_keys( WC()->session->get_session_data() ) as $session_key ) {
+			if ( 0 === strpos( $session_key, 'shipping_for_package_' ) ) {
+				WC()->session->__unset( $session_key );
+			}
+		}
 	}
 
 	/**

--- a/klarna-shipping-service-for-woocommerce.php
+++ b/klarna-shipping-service-for-woocommerce.php
@@ -208,6 +208,15 @@ class Klarna_Shipping_Service_For_WooCommerce {
 				$order->update_meta_data( '_kco_kss_reference', $shipping_details['tms_reference'] );
 			}
 
+			// Update the shipping details with the override data if it exists, since we want to save the overridden shipping details to the order, not the original ones from KSS.
+			$override_data = get_transient( "kss_override_data_$kco_id" );
+			if ( $override_data ) {
+				$shipping_details['price']      = $override_data['price'] ?? $shipping_details['price'];
+				$shipping_details['name']       = $override_data['name'] ?? $shipping_details['name'];
+				$shipping_details['tax_rate']   = $override_data['tax_rate'] ?? $shipping_details['tax_rate'];
+				$shipping_details['tax_amount'] = $override_data['tax_amount'] ?? $shipping_details['tax_amount'];
+			}
+
 			$order->update_meta_data( '_kco_kss_data', wp_json_encode( $shipping_details, JSON_UNESCAPED_UNICODE ) );
 			$order->save();
 			WC()->session->__unset( 'kco_kss_enabled' );
@@ -225,19 +234,14 @@ class Klarna_Shipping_Service_For_WooCommerce {
 	public function clear_shipping_and_recalculate() {
 		if ( 'kco' === WC()->session->get( 'chosen_payment_method' ) ) {
 			WC()->session->set( 'kco_kss_enabled', true );
-			$packages = WC()->cart->get_shipping_packages();
-			foreach ( $packages as $package_key => $package ) {
-				$session_key = 'shipping_for_package_' . $package_key;
-				WC()->session->__unset( $session_key );
-			}
 		} elseif ( null !== WC()->session->get( 'kco_kss_enabled' ) ) {
-				WC()->session->__unset( 'kco_kss_enabled' );
-				$packages = WC()->cart->get_shipping_packages();
-			foreach ( $packages as $package_key => $package ) {
-				$session_key = 'shipping_for_package_' . $package_key;
-				WC()->session->__unset( $session_key );
-			}
+			WC()->session->__unset( 'kco_kss_enabled' );
 		}
+
+		// Bump the shipping transient version so WooCommerce re-runs shipping for ALL packages,
+		// including Subscriptions' recurring packages (their package hash doesn't change when the
+		// override transient changes, so unsetting only the main-cart package keys isn't enough).
+		WC_Cache_Helper::get_transient_version( 'shipping', true );
 	}
 
 	/**

--- a/klarna-shipping-service-for-woocommerce.php
+++ b/klarna-shipping-service-for-woocommerce.php
@@ -33,7 +33,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-
 // Define plugin constants.
 define( 'KLARNA_KSS_VERSION', '1.3.1' );
 define( 'KLARNA_KSS_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
@@ -43,11 +42,66 @@ define( 'KLARNA_KSS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
  * Plugin main class.
  */
 class Klarna_Shipping_Service_For_WooCommerce {
+	/**
+	 * The reference the *Singleton* instance of this class.
+	 *
+	 * @var Klarna_Shipping_Service_For_WooCommerce $instance
+	 */
+	private static $instance = null;
+
+	/**
+	 * The hook registry instance.
+	 *
+	 * @var \Krokedil\KustomShippingService\HookRegistry
+	 */
+	protected $hook_registry;
+
+	/**
+	 * The API registry instance.
+	 *
+	 * @var \Krokedil\KustomShippingService\API\ApiRegistry
+	 */
+	protected $api_registry;
+
+	/**
+	 * Returns the *Singleton* instance of this class.
+	 *
+	 * @return Klarna_Shipping_Service_For_WooCommerce The *Singleton* instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Private clone method to prevent cloning of the instance of the
+	 * *Singleton* instance.
+	 *
+	 * @return void
+	 */
+	private function __clone() {
+		wc_doing_it_wrong( __FUNCTION__, __( 'Nope', 'klarna-shipping-service-for-woocommerce' ), '1.0' );
+	}
+
+	/**
+	 * Private unserialize method to prevent unserializing of the *Singleton*
+	 * instance.
+	 *
+	 * @return void
+	 */
+	public function __wakeup() {
+		wc_doing_it_wrong( __FUNCTION__, __( 'Nope', 'klarna-shipping-service-for-woocommerce' ), '1.0' );
+	}
 
 	/**
 	 * Class constructor.
+	 *
+	 * @return void
 	 */
-	public function __construct() {
+	protected function __construct() {
 		add_action( 'plugins_loaded', array( $this, 'init' ) );
 		add_action( 'plugins_loaded', array( $this, 'check_version' ) );
 		add_action( 'kco_wc_process_payment', array( $this, 'add_shipping_details_to_order' ), 10, 2 );
@@ -101,16 +155,25 @@ class Klarna_Shipping_Service_For_WooCommerce {
 	 * @return void
 	 */
 	public function include_files() {
+		// Include the autoloader from composer. If it fails, we'll just return and not load the plugin. But an admin notice will show to the merchant.
+		if ( ! self::init_composer() ) {
+			return;
+		}
+
 		// Include classes.
 		if ( is_admin() ) {
 			include_once KLARNA_KSS_PATH . '/classes/class-kss-admin-notices.php';
 		}
+
 		include_once KLARNA_KSS_PATH . '/classes/class-kss-cart-page.php';
 		include_once KLARNA_KSS_PATH . '/classes/class-kss-shipping-method.php';
 		include_once KLARNA_KSS_PATH . '/classes/class-kss-order-lines.php';
 		include_once KLARNA_KSS_PATH . '/classes/class-kss-free-orders.php';
 		include_once KLARNA_KSS_PATH . '/classes/class-kss-edit-klarna-order.php';
 		include_once KLARNA_KSS_PATH . '/classes/class-kss-compare-totals.php';
+
+		$this->hook_registry = new \Krokedil\KustomShippingService\HookRegistry();
+		$this->api_registry  = new \Krokedil\KustomShippingService\API\ApiRegistry();
 	}
 
 	/**
@@ -137,7 +200,8 @@ class Klarna_Shipping_Service_For_WooCommerce {
 	 */
 	public function add_shipping_details_to_order( $order_id, $klarna_order ) {
 		if ( isset( $klarna_order['selected_shipping_option'] ) ) {
-			$order = wc_get_order( $order_id );
+			$kco_id = $klarna_order['id'];
+			$order  = wc_get_order( $order_id );
 
 			$shipping_details = $klarna_order['selected_shipping_option'];
 			if ( isset( $shipping_details['tms_reference'] ) ) {
@@ -147,6 +211,9 @@ class Klarna_Shipping_Service_For_WooCommerce {
 			$order->update_meta_data( '_kco_kss_data', wp_json_encode( $shipping_details, JSON_UNESCAPED_UNICODE ) );
 			$order->save();
 			WC()->session->__unset( 'kco_kss_enabled' );
+
+			// Clear the kss_override_data_{order_id} transient since we have now saved the shipping data to the order.
+			delete_transient( "kss_override_data_$kco_id" );
 		}
 	}
 
@@ -177,12 +244,12 @@ class Klarna_Shipping_Service_For_WooCommerce {
 	 * Make sure that KCO iframe is displayed in checkout even if order total is 0.
 	 * This is needed so we can save the tms data to the Woo order.
 	 *
-	 * @param bool $bool Wether or not the plugin should check if KCO checkout should be displayed. Defaults to true.
+	 * @param bool $needs_payment Wether or not the plugin should check if KCO checkout should be displayed. Defaults to true.
 	 *
 	 * @return bool
 	 */
-	public function change_check_if_needs_payment( $bool ) {
-		// Allways return false. We want to display the KCO iframe even if order total is 0.
+	public function change_check_if_needs_payment( $needs_payment ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- We need to have the $needs_payment parameter to be able to use this as a filter for 'kco_check_if_needs_payment'.
+		// Always return false. We want to display the KCO iframe even if order total is 0.
 		return false;
 	}
 
@@ -200,5 +267,84 @@ class Klarna_Shipping_Service_For_WooCommerce {
 			'klarna-shipping-service-for-woocommerce'
 		);
 	}
+
+	/**
+	 * Get the instance of the hook registry class.
+	 *
+	 * @return Krokedil\KustomShippingService\HookRegistry
+	 */
+	public function hook_registry() {
+		return $this->hook_registry;
+	}
+
+	/**
+	 * Get the instance of the API registry class.
+	 *
+	 * @return Krokedil\KustomShippingService\API\ApiRegistry
+	 */
+	public function api_registry() {
+		return $this->api_registry;
+	}
+
+	/**
+	 * Initialize composers autoloader. If it does not exist, bail and show an error.
+	 *
+	 * @return mixed
+	 */
+	private static function init_composer() {
+		$autoloader = KLARNA_KSS_PATH . '/vendor/autoload.php';
+
+		if ( ! is_readable( $autoloader ) ) {
+			self::missing_autoloader();
+			return false;
+		}
+
+		$autoloader_result = require $autoloader;
+
+		if ( ! $autoloader_result ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Print error message for missing autoloader.
+	 *
+	 * @return void
+	 */
+	private static function missing_autoloader() {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			error_log( // phpcs:ignore
+				esc_html__( 'Your installation of Kustom Shipping Assistant for WooCommerce is not complete. If you installed this plugin directly from Github please refer to the README.DEV.md file in the plugin.', 'klarna-shipping-service-for-woocommerce' )
+			);
+		}
+
+		add_action(
+			'admin_notices',
+			function () {
+				?>
+					<div class="notice notice-error">
+						<p>
+							<?php echo esc_html__( 'Your installation of Kustom Shipping Assistant for WooCommerce is not complete. If you installed this plugin directly from Github please refer to the README.DEV.md file in the plugin.', 'klarna-shipping-service-for-woocommerce' ); ?>
+						</p>
+					</div>
+				<?php
+			}
+		);
+	}
 }
-new Klarna_Shipping_Service_For_WooCommerce();
+
+/**
+ * Main instance of Kustom Shipping Assistant.
+ *
+ * Returns the main instance of Kustom Shipping Assistant.
+ *
+ * @return Klarna_Shipping_Service_For_WooCommerce
+ */
+function kustom_shipping_assistant() { // phpcs:ignore
+	return Klarna_Shipping_Service_For_WooCommerce::get_instance();
+}
+
+// Create a instance of the plugin to load it.
+kustom_shipping_assistant();

--- a/klarna-shipping-service-for-woocommerce.php
+++ b/klarna-shipping-service-for-woocommerce.php
@@ -239,7 +239,7 @@ class Klarna_Shipping_Service_For_WooCommerce {
 		}
 
 		// Clear this customer's cached shipping rates so WooCommerce re-runs shipping on the next
-		// calculation. We unset every 'shipping_for_package_*' session key (not just the main-cart packages)
+		// calculation. We unset every 'shipping_for_package_*' session key (not just the main-cart packages).
 		foreach ( array_keys( WC()->session->get_session_data() ) as $session_key ) {
 			if ( 0 === strpos( $session_key, 'shipping_for_package_' ) ) {
 				WC()->session->__unset( $session_key );
@@ -323,7 +323,7 @@ class Klarna_Shipping_Service_For_WooCommerce {
 	private static function missing_autoloader() {
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			error_log( // phpcs:ignore
-				esc_html__( 'Your installation of Kustom Shipping Assistant for WooCommerce is not complete. If you installed this plugin directly from Github please refer to the README.DEV.md file in the plugin.', 'klarna-shipping-service-for-woocommerce' )
+				esc_html__( 'Your installation of Kustom Shipping Assistant for WooCommerce is not complete. If you installed this plugin directly from Github please refer to the readme.dev.md file in the plugin.', 'klarna-shipping-service-for-woocommerce' )
 			);
 		}
 
@@ -333,7 +333,7 @@ class Klarna_Shipping_Service_For_WooCommerce {
 				?>
 					<div class="notice notice-error">
 						<p>
-							<?php echo esc_html__( 'Your installation of Kustom Shipping Assistant for WooCommerce is not complete. If you installed this plugin directly from Github please refer to the README.DEV.md file in the plugin.', 'klarna-shipping-service-for-woocommerce' ); ?>
+							<?php echo esc_html__( 'Your installation of Kustom Shipping Assistant for WooCommerce is not complete. If you installed this plugin directly from Github please refer to the readme.dev.md file in the plugin.', 'klarna-shipping-service-for-woocommerce' ); ?>
 						</p>
 					</div>
 				<?php

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<ruleset name="Krokedil Coding Standards">
+    <description>WooCommerce dev PHP_CodeSniffer ruleset.</description>
+
+    <!-- Exclude vendor and node_modules from all rules -->
+    <exclude-pattern>*/node_modules/*</exclude-pattern>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/dependencies/*</exclude-pattern>
+
+    <!-- Exclude the tests folder -->
+    <exclude-pattern>tests/*</exclude-pattern>
+
+    <config name="minimum_supported_wp_version" value="6.2" />
+    <config name="testVersion" value="7.3-" />
+
+    <!-- Use Wordpress Coding standards -->
+    <rule ref="WordPress" />
+
+    <!-- Enforce the correct text-domain -->
+    <rule ref="WordPress.WP.I18n">
+        <properties>
+            <property name="text_domain" type="array">
+                <element value="klarna-shipping-service-for-woocommerce" />
+                <element value="woocommerce" />
+            </property>
+        </properties>
+    </rule>
+
+    <!--  Remove WordPress.Files.FileName.InvalidClassFileName checks to allow for PSR-4 naming
+    convention -->
+    <rule ref="WordPress.Files.FileName.InvalidClassFileName">
+        <exclude-pattern>src/</exclude-pattern>
+    </rule>
+
+    <!-- Remove WordPress.Files.FileName.NotHyphenatedLowercase checks to allow for PSR-4 naming
+    convention -->
+    <rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
+        <exclude-pattern>src/</exclude-pattern>
+    </rule>
+
+    <!-- Remove need for package tag in file block comments -->
+    <rule ref="Squiz.Commenting.FileComment.MissingPackageTag">
+        <exclude-pattern>src/</exclude-pattern>
+    </rule>
+
+    <!-- Remove need for file comment -->
+    <rule ref="Squiz.Commenting.FileComment.Missing">
+        <exclude-pattern>src/</exclude-pattern>
+    </rule>
+
+    <!-- Allow the usage of shorthand arrays -->
+    <rule ref="Universal.Arrays.DisallowShortArraySyntax.Found">
+        <exclude-pattern>src/</exclude-pattern>
+    </rule>
+</ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,46 @@
+parameters:
+  ignoreErrors:
+    - message: '#^PHPDoc tag @return has invalid value \(self\:\:\$instance The \*Singleton\* instance\.\)\: Unexpected token "\$instance", expected \* at offset 78 on line 4$#'
+      identifier: phpDoc.parseError
+      count: 1
+      path: classes/class-kss-admin-notices.php
+
+    - message: '#^PHPDoc tag @var has invalid value \(\$instance\)\: Unexpected token "\$instance", expected type at offset 75 on line 4$#'
+      identifier: phpDoc.parseError
+      count: 1
+      path: classes/class-kss-admin-notices.php
+
+    - message: '#^Constant KLARNA_KSS_PATH not found\.$#'
+      identifier: constant.notFound
+      count: 1
+      path: classes/class-kss-cart-page.php
+
+    - message: '#^Binary operation "\+" between string and string results in an error\.$#'
+      identifier: binaryOp.invalid
+      count: 1
+      path: classes/class-kss-compare-totals.php
+
+    - message: '#^Function KCO_WC not found\.$#'
+      identifier: function.notFound
+      count: 2
+      path: classes/class-kss-free-orders.php
+
+    - message: '#^Right side of && is always true\.$#'
+      identifier: booleanAnd.rightAlwaysTrue
+      count: 1
+      path: classes/class-kss-free-orders.php
+
+    - message: '#^Constant WCML_MULTI_CURRENCIES_INDEPENDENT not found\.$#'
+      identifier: constant.notFound
+      count: 1
+      path: classes/class-kss-shipping-method.php
+
+    - message: '#^Access to an undefined property WooCommerce\:\:\$shipping\.$#'
+      identifier: property.notFound
+      count: 1
+      path: klarna-shipping-service-for-woocommerce.php
+
+    - message: '#^Call to static method buildUpdateChecker\(\) on an unknown class Puc_v4_Factory\.$#'
+      identifier: class.notFound
+      count: 1
+      path: klarna-shipping-service-for-woocommerce.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,36 @@
+includes:
+  - phpstan-baseline.neon
+
+# `phpstan-baseline.neon` captures the snapshot of pre-existing issues.
+# New violations fail the build; baseline shrinks as code is fixed.
+
+parameters:
+  level: 5
+  phpVersion: 70400
+  treatPhpDocTypesAsCertain: false
+
+  paths:
+    - klarna-shipping-service-for-woocommerce.php
+    - classes
+    - src
+
+  excludePaths:
+    - vendor
+    - node_modules (?)
+    - tests (?)
+    - assets (?)
+    - dependencies (?)
+
+  scanFiles:
+    - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
+    - vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php
+    - vendor/php-stubs/woocommerce-stubs/woocommerce-packages-stubs.php
+    - vendor/php-stubs/woocommerce-subscriptions-stubs/woocommerce-subscriptions-stubs.php
+
+  dynamicConstantNames:
+    - KLARNA_KSS_VERSION
+    - KLARNA_KSS_URL
+    - KLARNA_KSS_PATH
+
+  ignoreErrors:
+    - '#Function KCO_WC not found\.#'

--- a/readme.dev.md
+++ b/readme.dev.md
@@ -1,0 +1,10 @@
+# Installation
+If you are installing the plugin through a built zip file, then follow the standard installation from the [readme.txt](readme.txt) file.
+
+If you are cloning the plugin directly from Github, or downloading it in any other way other then from a built resource, then you will need to run composer to install the plugins composer dependencies.
+
+For this you will need to have the following:
+* [PHP 8.2.*](https://www.php.net/manual/en/install.php). Make sure you have the necessary extensions installed, such as `curl`, `mbstring`, `xml`, and `zip`. For the scoping of dependencies, version 8.2 of PHP is required.
+* [Composer](https://getcomposer.org/doc/00-intro.md).
+
+After these are installed you can run `composer install` from the plugins directory in your CLI. The first command will install all packages, including the once only required for development and scoping of dependencies. After that you can run `composer install --no-dev` to only install the packages required for the plugin to run, but only after the plugin has been successfully scoped.

--- a/readme.dev.md
+++ b/readme.dev.md
@@ -1,10 +1,10 @@
 # Installation
 If you are installing the plugin through a built zip file, then follow the standard installation from the [readme.txt](readme.txt) file.
 
-If you are cloning the plugin directly from Github, or downloading it in any other way other then from a built resource, then you will need to run composer to install the plugins composer dependencies.
+If you are cloning the plugin directly from GitHub, or downloading it in any other way other than from a built resource, then you will need to run Composer to install the plugin's Composer dependencies.
 
 For this you will need to have the following:
 * [PHP 8.2.*](https://www.php.net/manual/en/install.php). Make sure you have the necessary extensions installed, such as `curl`, `mbstring`, `xml`, and `zip`. For the scoping of dependencies, version 8.2 of PHP is required.
 * [Composer](https://getcomposer.org/doc/00-intro.md).
 
-After these are installed you can run `composer install` from the plugins directory in your CLI. The first command will install all packages, including the once only required for development and scoping of dependencies. After that you can run `composer install --no-dev` to only install the packages required for the plugin to run, but only after the plugin has been successfully scoped.
+After these are installed you can run `composer install` from the plugins directory in your CLI. The first command will install all packages, including the ones only required for development and scoping of dependencies. After that you can run `composer install --no-dev` to only install the packages required for the plugin to run, but only after the plugin has been successfully scoped.

--- a/src/API/ApiRegistry.php
+++ b/src/API/ApiRegistry.php
@@ -1,0 +1,82 @@
+<?php
+namespace Krokedil\KustomShippingService\API;
+
+use Krokedil\KustomShippingService\API\Controllers\{BaseController, ShippingOptionUpdateController};
+
+\defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ApiRegistry.
+ *
+ * Register the API controllers for the Kustom Shipping Service plugin with WordPress.
+ *
+ * @package Krokedil\KustomShippingService\API
+ */
+class ApiRegistry {
+	/**
+	 * The list of controllers.
+	 *
+	 * @var BaseController[]
+	 */
+	protected $controllers = array();
+
+	/**
+	 * Class constructor.
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Initialize the API controllers and models.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		$this->register_controller( new ShippingOptionUpdateController() );
+
+		add_action( 'rest_api_init', array( $this, 'register_controller_routes' ) );
+	}
+
+	/**
+	 * Register the controllers.
+	 *
+	 * @return void
+	 */
+	public function register_controller_routes() {
+		foreach ( $this->controllers as $controller ) {
+			$controller->register_routes();
+		}
+	}
+
+	/**
+	 * Register a controller.
+	 *
+	 * @param BaseController $controller The controller to register.
+	 *
+	 * @return void
+	 */
+	public function register_controller( BaseController $controller ) {
+		$this->controllers[ \get_class( $controller ) ] = $controller;
+	}
+
+	/**
+	 * Get the request path for a specific controller.
+	 *
+	 * @param string $controller The controller class name to get the path for.
+	 * @param string $endpoint The endpoint to get the path for.
+	 *
+	 * @return string
+	 */
+	public function get_request_path( string $controller, string $endpoint = '' ) {
+		if ( isset( $this->controllers[ $controller ] ) ) {
+			$path    = trim( $this->controllers[ $controller ]->get_request_path(), '/' );
+			$blog_id = get_current_blog_id();
+			return get_rest_url( empty( $blog_id ) ? null : $blog_id, "kustom/shipping-service/$path/$endpoint" );
+		}
+
+		return '';
+	}
+}

--- a/src/API/Controllers/BaseController.php
+++ b/src/API/Controllers/BaseController.php
@@ -1,0 +1,64 @@
+<?php
+namespace Krokedil\KustomShippingService\API\Controllers;
+
+\defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class BaseController.
+ *
+ * Base class for REST API controllers in the Kustom Shipping Service plugin.
+ *
+ * @package Krokedil\KustomShippingService\API\Controllers
+ */
+abstract class BaseController {
+	/**
+	 * The namespace of the controller.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'kustom/shipping-service';
+
+	/**
+	 * The version of the controller.
+	 *
+	 * @var string
+	 */
+	protected $version = 'v1';
+
+	/**
+	 * The path of the controller.
+	 *
+	 * @var string
+	 */
+	protected $path;
+
+	/**
+	 * Get the base path for the controller.
+	 *
+	 * @return string
+	 */
+	protected function get_base_path() {
+		// Combine the version and path to create the base path, ensuring that the path doesn't start or end with a slash.
+		return trim( "{$this->version}/{$this->path}", '/' );
+	}
+
+	/**
+	 * Get the request path for a specific endpoint.
+	 *
+	 * @param string $endpoint The endpoint to get the path for.
+	 *
+	 * @return string
+	 */
+	public function get_request_path( $endpoint = '' ) {
+		$base_path = $this->get_base_path();
+		$endpoint  = trim( $endpoint, '/' );
+		return "{$base_path}/{$endpoint}";
+	}
+
+	/**
+	 * Register the routes for the objects of the controller.
+	 *
+	 * @return void
+	 */
+	abstract public function register_routes();
+}

--- a/src/API/Controllers/ShippingOptionUpdateController.php
+++ b/src/API/Controllers/ShippingOptionUpdateController.php
@@ -27,7 +27,7 @@ class ShippingOptionUpdateController extends BaseController {
 		// Register the callback route for the controller.
 		register_rest_route(
 			$this->namespace,
-			$this->get_request_path('shipping-option-update'),
+			$this->get_request_path( 'shipping-option-update' ),
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'handle_shipping_option_update' ),
@@ -61,7 +61,7 @@ class ShippingOptionUpdateController extends BaseController {
 		}
 
 		// Ensure the order has the correct status.
-		if ( $kco_order['status'] !== 'checkout_incomplete' ) {
+		if ( 'checkout_incomplete' !== $kco_order['status'] ) {
 			return false;
 		}
 
@@ -74,12 +74,13 @@ class ShippingOptionUpdateController extends BaseController {
 	 * @param \WP_REST_Request $request The REST request object.
 	 *
 	 * @return \WP_REST_Response The REST response object.
+	 * @throws \Exception If an error occurs while processing the request.
 	 */
 	public function handle_shipping_option_update( $request ) {
 		$body   = $request->get_json_params();
 		$kco_id = $request->get_param( 'kco_id' );
 
-		try{
+		try {
 			// If the body is empty, return an error response.
 			if ( empty( $body ) ) {
 				throw new \Exception( 'Request body is empty' );
@@ -104,7 +105,7 @@ class ShippingOptionUpdateController extends BaseController {
 	/**
 	 * Get response body
 	 *
-	 * @param array $body The request body.
+	 * @param array  $body The request body.
 	 * @param string $kco_id The KCO order id.
 	 *
 	 * @return array The response body.
@@ -225,9 +226,12 @@ class ShippingOptionUpdateController extends BaseController {
 		$order_lines = $body['order_lines'] ?? array();
 
 		// Remove any existing shipping order lines from the order lines array.
-		$order_lines = array_filter( $order_lines, function( $line ) {
-			return $line['type'] !== 'shipping_fee';
-		} );
+		$order_lines = array_filter(
+			$order_lines,
+			function ( $line ) {
+				return ( $line['type'] ?? '' ) !== 'shipping_fee';
+			}
+		);
 
 		$order_lines[] = $shipping_order_line;
 
@@ -243,9 +247,13 @@ class ShippingOptionUpdateController extends BaseController {
 	 * @return int The summed amount.
 	 */
 	private function calculate_order_total( $order_lines, $key ) {
-		return array_reduce( $order_lines, function( $carry, $line ) use ( $key ) {
-			return $carry + ( $line[ $key ] ?? 0 );
-		}, 0 );
+		return array_reduce(
+			$order_lines,
+			function ( $carry, $line ) use ( $key ) {
+				return $carry + ( $line[ $key ] ?? 0 );
+			},
+			0
+		);
 	}
 
 	/**
@@ -352,14 +360,24 @@ class ShippingOptionUpdateController extends BaseController {
 	 * @return array The filtered response.
 	 */
 	private function filter_response( $response ) {
-		return array_filter( $response, function( $value ) {
+		foreach ( $response as $key => $value ) {
 			// If the value is an array, we need to filter it recursively.
 			if ( is_array( $value ) ) {
-				return ! empty( $this->filter_response( $value ) );
+				$value = $this->filter_response( $value );
+				if ( empty( $value ) ) {
+					unset( $response[ $key ] );
+					continue;
+				}
+				$response[ $key ] = $value;
+				continue;
 			}
 
-			return null !== $value;
-		} );
+			// If the value is null, remove it from the response.
+			if ( null === $value ) {
+				unset( $response[ $key ] );
+			}
+		}
+		return $response;
 	}
 
 	/**

--- a/src/API/Controllers/ShippingOptionUpdateController.php
+++ b/src/API/Controllers/ShippingOptionUpdateController.php
@@ -314,8 +314,17 @@ class ShippingOptionUpdateController extends BaseController {
 		$customer->set_shipping_state( $shipping_address['state'] ?? null );
 		$customer->set_shipping_postcode( $shipping_address['postal_code'] ?? null );
 
-		// Get the shipping tax rate for the customer's location.
-		$tax_rates = \WC_Tax::get_shipping_tax_rates( null, $customer );
+		/**
+		 *  Get the shipping tax rate for the customer's location.
+		 *
+		 *  We need to pass the default tax class (empty string) to ensure we don't attempt to get it from the cart, which is not available in this context.
+		 *  If the tax class is not configured with any rates that matches the customers location, this will return an empty array,
+		 *  but only if there is no set shipping tax class, that always overrides the passed shipping tax class. Meaning the calculation will still
+		 *  match what WooCommerce would calculate as well, since if no shipping tax is found that matches the cart if its set to inherit, it will return an empty array as well.
+		 *
+		 * @see https://github.com/woocommerce/woocommerce/blob/04789354c046f36835f629b7e3ccfc66d4173f17/plugins/woocommerce/includes/class-wc-tax.php#L566-L583
+		 */
+		$tax_rates = \WC_Tax::get_shipping_tax_rates( '', $customer );
 
 		// If we don't have any tax rates, return an empty array.
 		if ( empty( $tax_rates ) ) {

--- a/src/API/Controllers/ShippingOptionUpdateController.php
+++ b/src/API/Controllers/ShippingOptionUpdateController.php
@@ -1,0 +1,379 @@
+<?php
+namespace Krokedil\KustomShippingService\API\Controllers;
+
+\defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ShippingOptionUpdateController.
+ *
+ * Controller for handling the shipping option update callback from Kustom Shipping Service.
+ *
+ * @package Krokedil\KustomShippingService\API\Controllers
+ */
+class ShippingOptionUpdateController extends BaseController {
+	/**
+	 * The path of the controller.
+	 *
+	 * @var string
+	 */
+	protected $path = 'callback';
+
+	/**
+	 * Register the routes for the controller.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		// Register the callback route for the controller.
+		register_rest_route(
+			$this->namespace,
+			$this->get_request_path('shipping-option-update'),
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_shipping_option_update' ),
+				'permission_callback' => array( $this, 'verify_request' ),
+			)
+		);
+	}
+
+	/**
+	 * Verify the request before processing it.
+	 *
+	 * @param \WP_REST_Request $request The REST request object.
+	 *
+	 * @return bool True if the request is valid, false otherwise.
+	 */
+	public function verify_request( $request ) {
+		// Get the KCO order ID from the request parameters.
+		$kco_id = $request->get_param( 'kco_id' );
+
+		// If the KCO order ID is not present, return false.
+		if ( ! $kco_id ) {
+			return false;
+		}
+
+		// Get the order from Kustom.
+		$kco_order = KCO_WC()->api->get_klarna_order( $kco_id );
+
+		// If the order is not found return false.
+		if ( is_wp_error( $kco_order ) ) {
+			return false;
+		}
+
+		// Ensure the order has the correct status.
+		if ( $kco_order['status'] !== 'checkout_incomplete' ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Handle the shipping option update callback from Kustom Shipping Service.
+	 *
+	 * @param \WP_REST_Request $request The REST request object.
+	 *
+	 * @return \WP_REST_Response The REST response object.
+	 */
+	public function handle_shipping_option_update( $request ) {
+		$body   = $request->get_json_params();
+		$kco_id = $request->get_param( 'kco_id' );
+
+		try{
+			// If the body is empty, return an error response.
+			if ( empty( $body ) ) {
+				throw new \Exception( 'Request body is empty' );
+			}
+
+			// Get the selected shipping option from the request body.
+			$selected_shipping_option = $body['selected_shipping_option'] ?? null;
+
+			// If the selected shipping option is not set, return an error response.
+			if ( ! $selected_shipping_option ) {
+				throw new \Exception( 'Selected shipping option not provided' );
+			}
+
+			// Return the response body.
+			return $this->success_response( $this->get_response_body( $body, $kco_id ) );
+		} catch ( \Exception $e ) {
+			KCO_WC()->logger->log( '[KSA Callback] shipping option update failed for kco_id ' . $kco_id . ': ' . $e->getMessage() );
+			return new \WP_REST_Response( array( 'error' => 'An error occurred while processing the request' ), 500 );
+		}
+	}
+
+	/**
+	 * Get response body
+	 *
+	 * @param array $body The request body.
+	 * @param string $kco_id The KCO order id.
+	 *
+	 * @return array The response body.
+	 */
+	private function get_response_body( $body, $kco_id ) {
+		$shipping_option     = $this->build_shipping_option( $body );
+		$shipping_order_line = $this->build_shipping_order_line( $shipping_option );
+
+		// If the order is a free trial subscription, shipping must be free, so zero out the price and tax.
+		if ( $this->is_free_trial_shipping( $body ) ) {
+			$this->apply_free_trial_override( $shipping_option, $shipping_order_line );
+		}
+
+		$order_lines = $this->build_order_lines( $body, $shipping_order_line );
+		$response    = $this->build_response( $body, $order_lines );
+
+		// Set the override transient to be used in the shipping method class.
+		$this->store_override_data( $kco_id, $shipping_option );
+
+		return $this->filter_response( $response );
+	}
+
+	/**
+	 * Build the shipping option from the request body, including the calculated shipping tax.
+	 *
+	 * @param array $body The request body.
+	 *
+	 * @return array The shipping option.
+	 */
+	private function build_shipping_option( $body ) {
+		$shipping_tax_rates  = $this->get_shipping_tax_rates( $body['billing_address'] ?? array(), $body['shipping_address'] ?? array() );
+		$shipping_tax_amount = $this->calculate_shipping_tax_amount( $body['selected_shipping_option']['price'] ?? 0, $shipping_tax_rates );
+
+		$selected_shipping_option = $body['selected_shipping_option'] ?? array();
+
+		return array(
+			'id'               => $selected_shipping_option['id'] ?? 'default_shipping_option',
+			'name'             => $selected_shipping_option['name'] ?? 'Default Shipping Option',
+			'price'            => $selected_shipping_option['price'] ?? 0,
+			'tax_amount'       => $shipping_tax_amount,
+			'tax_rate'         => $this->get_tax_rate_percentage( $shipping_tax_rates ),
+			'preselected'      => $selected_shipping_option['preselected'] ?? true,
+			'shipping_method'  => $selected_shipping_option['shipping_method'] ?? null,
+			'delivery_details' => $selected_shipping_option['delivery_details'] ?? null,
+			'tms_reference'    => $selected_shipping_option['tms_reference'] ?? null,
+			'tos_id'           => $selected_shipping_option['tos_id'] ?? null,
+			'selected_addons'  => $selected_shipping_option['selected_addons'] ?? null,
+		);
+	}
+
+	/**
+	 * Get the shipping tax rate as a whole-number percentage.
+	 *
+	 * @param array $shipping_tax_rates The shipping tax rates.
+	 *
+	 * @return int The tax rate as a percentage (e.g. 25 for 25%).
+	 */
+	private function get_tax_rate_percentage( $shipping_tax_rates ) {
+		$tax_rate = $shipping_tax_rates ? reset( $shipping_tax_rates ) : null;
+		$tax_rate = $tax_rate ? $tax_rate['rate'] : 0;
+
+		return intval( round( $tax_rate * 100 ) ); // Convert to percentage.
+	}
+
+	/**
+	 * Build the shipping order line from the shipping option.
+	 *
+	 * @param array $shipping_option The shipping option.
+	 *
+	 * @return array The shipping order line.
+	 */
+	private function build_shipping_order_line( $shipping_option ) {
+		return array(
+			'type'             => 'shipping_fee',
+			'reference'        => $shipping_option['id'],
+			'name'             => $shipping_option['name'],
+			'quantity'         => 1,
+			'unit_price'       => $shipping_option['price'],
+			'tax_rate'         => $shipping_option['tax_rate'],
+			'total_amount'     => $shipping_option['price'],
+			'total_tax_amount' => $shipping_option['tax_amount'],
+		);
+	}
+
+	/**
+	 * Whether the order is a free trial subscription where shipping should be free.
+	 *
+	 * @param array $body The request body.
+	 *
+	 * @return bool True if the free trial shipping tag is present.
+	 */
+	private function is_free_trial_shipping( $body ) {
+		return in_array( 'ksa_subscription_free_trial_shipping', $body['tags'] ?? array(), true );
+	}
+
+	/**
+	 * Zero out the shipping price and tax on both the shipping option and its order line.
+	 *
+	 * @param array $shipping_option     The shipping option (modified by reference).
+	 * @param array $shipping_order_line The shipping order line (modified by reference).
+	 *
+	 * @return void
+	 */
+	private function apply_free_trial_override( &$shipping_option, &$shipping_order_line ) {
+		$shipping_option['price']      = 0;
+		$shipping_option['tax_amount'] = 0;
+
+		$shipping_order_line['unit_price']       = 0;
+		$shipping_order_line['total_amount']     = 0;
+		$shipping_order_line['total_tax_amount'] = 0;
+	}
+
+	/**
+	 * Build the order lines, replacing any existing shipping line with the new one.
+	 *
+	 * @param array $body                The request body.
+	 * @param array $shipping_order_line The shipping order line to append.
+	 *
+	 * @return array The order lines.
+	 */
+	private function build_order_lines( $body, $shipping_order_line ) {
+		$order_lines = $body['order_lines'] ?? array();
+
+		// Remove any existing shipping order lines from the order lines array.
+		$order_lines = array_filter( $order_lines, function( $line ) {
+			return $line['type'] !== 'shipping_fee';
+		} );
+
+		$order_lines[] = $shipping_order_line;
+
+		return $order_lines;
+	}
+
+	/**
+	 * Sum a given amount field across all order lines.
+	 *
+	 * @param array  $order_lines The order lines.
+	 * @param string $key         The order line field to sum (e.g. 'total_amount').
+	 *
+	 * @return int The summed amount.
+	 */
+	private function calculate_order_total( $order_lines, $key ) {
+		return array_reduce( $order_lines, function( $carry, $line ) use ( $key ) {
+			return $carry + ( $line[ $key ] ?? 0 );
+		}, 0 );
+	}
+
+	/**
+	 * Build the response body returned to Kustom.
+	 *
+	 * @param array $body        The request body.
+	 * @param array $order_lines The order lines.
+	 *
+	 * @return array The response body.
+	 */
+	private function build_response( $body, $order_lines ) {
+		return array(
+			'order_amount'             => $this->calculate_order_total( $order_lines, 'total_amount' ),
+			'order_tax_amount'         => $this->calculate_order_total( $order_lines, 'total_tax_amount' ),
+			'merchant_data'            => $body['merchant_data'] ?? null,
+			'order_lines'              => $order_lines,
+			'attachments'              => $body['attachments'] ?? null,
+			'purchase_currency'        => $body['purchase_currency'] ?? get_woocommerce_currency(),
+			'locale'                   => $body['locale'] ?? get_locale(),
+			'external_payment_methods' => $body['external_payment_methods'] ?? null,
+			'tags'                     => $body['tags'] ?? null,
+		);
+	}
+
+	/**
+	 * Store the shipping override data in a transient for use in the shipping method class.
+	 *
+	 * @param string $kco_id          The KCO order id.
+	 * @param array  $shipping_option The shipping option.
+	 *
+	 * @return void
+	 */
+	private function store_override_data( $kco_id, $shipping_option ) {
+		$kss_override_data = array(
+			'name'       => $shipping_option['name'] ?? null,
+			'price'      => $shipping_option['price'] ?? null,
+			'tax_rate'   => $shipping_option['tax_rate'] ?? null,
+			'tax_amount' => $shipping_option['tax_amount'] ?? null,
+		);
+
+		set_transient( "kss_override_data_$kco_id", $kss_override_data, HOUR_IN_SECONDS );
+	}
+
+	/**
+	 * Get the WooCommerce tax rates to use for the customer address and shipping price.
+	 *
+	 * @param array $billing_address  The customer billing address details.
+	 * @param array $shipping_address The customer shipping address details.
+	 *
+	 * @return array The tax rates to use for the shipping option.
+	 */
+	private function get_shipping_tax_rates( $billing_address, $shipping_address ) {
+		$customer = new \WC_Customer();
+		$customer->set_billing_country( $billing_address['country'] ?? null );
+		$customer->set_billing_state( $billing_address['state'] ?? null );
+		$customer->set_billing_postcode( $billing_address['postal_code'] ?? null );
+		$customer->set_shipping_country( $shipping_address['country'] ?? null );
+		$customer->set_shipping_state( $shipping_address['state'] ?? null );
+		$customer->set_shipping_postcode( $shipping_address['postal_code'] ?? null );
+
+		// Get the shipping tax rate for the customer's location.
+		$tax_rates = \WC_Tax::get_shipping_tax_rates( null, $customer );
+
+		// If we don't have any tax rates, return an empty array.
+		if ( empty( $tax_rates ) ) {
+			return array();
+		}
+
+		// Get the first key and rate from the tax rates.
+		$rate_id = key( $tax_rates );
+		$rate    = $tax_rates[ $rate_id ];
+
+		return array(
+			$rate_id => $rate,
+		);
+	}
+
+	/**
+	 * Calculate the shipping tax amount based on the price including vat and the customer address details.
+	 *
+	 * @param int   $price The price including vat.
+	 * @param array $tax_rates The tax rates for the shipping option.
+	 *
+	 * @return int The calculated tax amount.
+	 */
+	private function calculate_shipping_tax_amount( $price, $tax_rates ) {
+		// Divide the price by 100 to get it in major units.
+		$price = $price / 100;
+
+		// Calculate the tax amount using the WooCommerce tax functions.
+		$tax_amount = \WC_Tax::calc_tax( $price, $tax_rates, true );
+
+		// Sum the array and multiply by 100 to get it back in minor units.
+		$tax_amount = intval( round( array_sum( $tax_amount ) * 100 ) );
+
+		return $tax_amount;
+	}
+
+	/**
+	 * Filter out any null values from the response to prevent Kustom from throwing an error.
+	 *
+	 * @param array $response The response to filter.
+	 *
+	 * @return array The filtered response.
+	 */
+	private function filter_response( $response ) {
+		return array_filter( $response, function( $value ) {
+			// If the value is an array, we need to filter it recursively.
+			if ( is_array( $value ) ) {
+				return ! empty( $this->filter_response( $value ) );
+			}
+
+			return null !== $value;
+		} );
+	}
+
+	/**
+	 * Return a successful response.
+	 *
+	 * @param array $response_body The response body to return.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function success_response( $response_body = array() ) {
+		return new \WP_REST_Response( $response_body, 200 );
+	}
+}

--- a/src/API/Controllers/ShippingOptionUpdateController.php
+++ b/src/API/Controllers/ShippingOptionUpdateController.php
@@ -115,7 +115,7 @@ class ShippingOptionUpdateController extends BaseController {
 
 		// If the order is a free trial subscription, shipping must be free, so zero out the price and tax.
 		if ( $this->is_free_trial_shipping( $body ) ) {
-			$this->apply_free_trial_override( $shipping_option, $shipping_order_line );
+			$this->apply_free_trial_override( $shipping_order_line );
 		}
 
 		$order_lines = $this->build_order_lines( $body, $shipping_order_line );
@@ -201,17 +201,13 @@ class ShippingOptionUpdateController extends BaseController {
 	}
 
 	/**
-	 * Zero out the shipping price and tax on both the shipping option and its order line.
+	 * Zero out the shipping price and tax on the shipping order line.
 	 *
-	 * @param array $shipping_option     The shipping option (modified by reference).
 	 * @param array $shipping_order_line The shipping order line (modified by reference).
 	 *
 	 * @return void
 	 */
-	private function apply_free_trial_override( &$shipping_option, &$shipping_order_line ) {
-		$shipping_option['price']      = 0;
-		$shipping_option['tax_amount'] = 0;
-
+	private function apply_free_trial_override( &$shipping_order_line ) {
 		$shipping_order_line['unit_price']       = 0;
 		$shipping_order_line['total_amount']     = 0;
 		$shipping_order_line['total_tax_amount'] = 0;

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -1,0 +1,133 @@
+<?php
+namespace Krokedil\KustomShippingService;
+
+use Krokedil\KustomShippingService\API\Controllers\ShippingOptionUpdateController;
+
+\defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class HookRegistry.
+ *
+ * Registers the hooks for the Kustom Shipping Service plugin with WordPress.
+ *
+ * @package Krokedil\KustomShippingService
+ */
+class HookRegistry {
+	/**
+	 * Class constructor.
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		add_filter( 'kco_wc_gateway_settings', array( $this, 'add_callback_settings' ) );
+		add_filter( 'kco_wc_merchant_urls', array( $this, 'maybe_add_shipping_option_change_callback_url' ) );
+		add_filter( 'kco_wc_api_request_args', array( $this, 'maybe_add_subscription_free_trial_tag' ) );
+	}
+
+	/**
+	 * Add the settings for the Kustom Shipping Service plugin to the KCO settings page.
+	 *
+	 * @param array $settings The existing settings for the KCO plugin.
+	 *
+	 * @return array The modified settings for the KCO plugin, including the settings for the Kustom Shipping Service plugin.
+	 */
+	public function add_callback_settings( $settings ) {
+		// Get the index for the 'shipping_section_end' setting, so we can add our setting as the last one before it.
+		$shipping_section_end_index = array_search( 'shipping_section_end', array_keys( $settings ), true );
+
+		// Insert our setting before the 'shipping_section_end' setting.
+		$settings = array_slice( $settings, 0, $shipping_section_end_index, true ) +
+			array(
+				'ksa_enable_shipping_option_update_callback' => array(
+					'title'       => __( 'Enable shipping option update callback', 'klarna-shipping-service-for-woocommerce' ),
+					'type'        => 'checkbox',
+					'label'       => __( 'Enable the shipping option update callback for Kustom Shipping Assistant to override shipping data from WooCommerce.', 'klarna-shipping-service-for-woocommerce' ),
+					'default'     => 'no',
+					'description' => __( 'Enabling this setting will allow WooCommerce to override shipping data from Kustom Shipping Assistant with data. For example if you need to override the tax rate used by shipping options in cases where the TMS does not provide the correct tax rate.', 'klarna-shipping-service-for-woocommerce' ),
+				),
+			) +
+			array_slice( $settings, $shipping_section_end_index, null, true );
+
+		return $settings;
+	}
+
+	/**
+	 * Maybe add the shipping option change callback URL to the merchant URLs array.
+	 *
+	 * @param array $merchant_urls The merchant URLs array.
+	 *
+	 * @return array The modified merchant URLs array.
+	 */
+	public function maybe_add_shipping_option_change_callback_url( $merchant_urls ) {
+		// Only if we have an actual cart that is not empty.
+		if ( ! WC()->cart || WC()->cart->is_empty() ) {
+			return $merchant_urls;
+		}
+
+		// If the cart does not need shipping, we don't need to add the shipping option update callback URL.
+		if ( ! WC()->cart->needs_shipping() ) {
+			return $merchant_urls;
+		}
+
+		// If the cart only has free trial subscriptions, we will always need to add the callback handler.
+		$is_free_trial_subscription = $this->cart_contains_only_free_trial_subscription();
+		$setting_enabled            = $this->is_shipping_option_update_callback_enabled();
+
+		// Only if the cart has a subscription and it's a free trial subscription. Otherwise only if the setting is enabled.
+		if ( ! $is_free_trial_subscription && ! $setting_enabled ) {
+			return $merchant_urls;
+		}
+
+		$merchant_urls['shipping_option_update'] = add_query_arg(
+			array( 'kco_id' => '{checkout.order.id}' ),
+			kustom_shipping_assistant()->api_registry()->get_request_path( ShippingOptionUpdateController::class, 'shipping-option-update'
+		) );
+
+		return $merchant_urls;
+	}
+
+	/**
+	 * Maybe add the subscription free trial tag to the Kustom Checkout request args.
+	 *
+	 * This is needed to ensure that the shipping option update callback URL is added for free trial subscriptions, since Kustom only adds the shipping option update callback URL if the "ksa_free_shipping" tag is present in the order.
+	 *
+	 * @param array $request_args The request args for Kustom Checkout.
+	 *
+	 * @return array The modified request args for Kustom Checkout.
+	 */
+	public function maybe_add_subscription_free_trial_tag( $request_args ) {
+		$tags = isset( $request_args['tags'] ) ? $request_args['tags'] : array();
+
+		if ( $this->cart_contains_only_free_trial_subscription() ) {
+			$tags[] = 'ksa_subscription_free_trial_shipping';
+		}
+
+		$request_args['tags'] = $tags;
+		return $request_args;
+	}
+
+	/**
+	 * Helper method to see if the current cart contains only a free trial subscription and the shipping should be zero for the initial purchase.
+	 *
+	 * @return bool True if the cart contains only a free trial subscription, false otherwise.
+	 */
+	private function cart_contains_only_free_trial_subscription() {
+		// If there is no cart or the cart is empty, return false.
+		if ( ! WC()->cart || WC()->cart->is_empty() ) {
+			return false;
+		}
+
+		// Check if the cart contains only free trial subscriptions.
+		return class_exists( 'WC_Subscriptions_Cart' ) && \WC_Subscriptions_Cart::all_cart_items_have_free_trial();
+	}
+
+	/**
+	 * Helper method to see if the setting to enable the callback is enabled or not.
+	 *
+	 * @return bool True if the setting is enabled, false otherwise.
+	 */
+	private function is_shipping_option_update_callback_enabled() {
+		$settings = get_option( 'woocommerce_kco_settings', array() );
+		return 'yes' === ( $settings['ksa_enable_shipping_option_update_callback'] ?? 'no' );
+	}
+}


### PR DESCRIPTION
## Summary

Adds a server-side **shipping option update callback** for Kustom Shipping Assistant (KSA) and uses it to fix shipping handling for **free-trial subscriptions**, where the initial purchase must ship for free but renewals must keep the real shipping price. Also brings the plugin in line with our current tooling (Composer autoloader, singleton bootstrap, PHPCS/PHPStan).

## Background

Normally the TMS provider owns shipping data end-to-end and we just read it back. There are cases where WooCommerce needs to *override* what the TMS sends:

- **Incorrect TMS tax rate** - the TMS may not know the correct shipping tax rate for the customer's location.
- **Free-trial subscriptions** - the first payment is 0, so initial shipping must be free, while the recurring/renewal order keeps the real shipping cost.

To support this we expose a REST callback that Kustom calls when the shopper changes their shipping option. WooCommerce recalculates price/tax, returns updated order lines/totals to Kustom, and mirrors the result locally so the WooCommerce side stays in sync.

## What's included

**Shipping option update callback (new `src/`)**
- `HookRegistry` - registers KCO filters: adds the "Enable shipping option update callback" gateway setting, conditionally injects the callback URL into the merchant URLs, and tags free-trial carts.
- `ApiRegistry` + `BaseController` + `ShippingOptionUpdateController` - register and handle the REST endpoint (`kustom/shipping-service/v1/callback/shipping-option-update`). The handler recalculates shipping tax from the customer address, rebuilds order lines/totals, and stores the result in a `kss_override_data_{kco_id}` transient.

**Free-trial subscription handling**
- Free-trial-only carts always get the callback wired up (regardless of the setting) and are tagged so the callback zeroes the *initial* shipping line.
- The override transient retains the *real* shipping price so renewal/recurring orders are priced correctly.

**Consuming the override on the WooCommerce side**
- `KSS_Shipping_Method::calculate_shipping()` merges override values (name/price/tax) into the shipping data when present, with a guard against empty shipping data.
- `KSS_Edit_Klarna_Order::remove_shipping()` keeps the shipping line in outgoing KCO requests when override data exists.
- **Recurring shipping fix:** `clear_shipping_and_recalculate()` now unsets *all* of the current customer's `shipping_for_package_*` session keys instead of only the main-cart packages. WC caches rates per package by a hash of the package *contents*, which don't change when the override transient changes - so the previous per-package clear never invalidated Subscriptions' recurring packages, leaving the displayed shipping method stale on free-trial checkouts (where shipping lives on the recurring cart, not the main cart). Clearing every package key for the session forces a recalculation of main + recurring packages, scoped to the current customer so the rest of the site's shipping cache is untouched.


**Tooling / housekeeping**
- Convert the main plugin class to a singleton with a `kustom_shipping_assistant()` bootstrap.
- Add Composer autoloader handling with an admin notice when `vendor/` is missing.
- Add `composer.json`/`composer.lock`, `phpcs.xml`, `phpstan.neon` + baseline, `readme.dev.md`, and update `.gitattributes` / `.gitignore` / `.kernlignore`.
- `Requires Plugins: woocommerce` header; bump "WC tested up to".

## Configuration

A new **"Enable shipping option update callback"** toggle on the KCO gateway settings page lets merchants opt in to the override (e.g. to correct a TMS tax rate). Free-trial carts use the callback automatically and don't require the setting.